### PR TITLE
Bug with non root user running threader3000

### DIFF
--- a/threader3000.py
+++ b/threader3000.py
@@ -109,7 +109,11 @@ def main():
                 print(outfile)
                 os.mkdir(target)
                 os.chdir(target)
-                os.system(outfile)
+                if os.geteuid() is not 0: # if user is not root
+                   # we are not running as root. Lets elevate priviledges to run nmap as root user.
+                  os.system("sudo " + outfile)
+                else:
+                  os.system(outfile)
                 #The xsltproc is experimental and will convert XML to a HTML readable format; requires xsltproc on your machine to work
                 #convert = "xsltproc "+target+".xml -o "+target+".html"
                 #os.system(convert)


### PR DESCRIPTION
It has been observed that if a user runs threader3000 and then proceeds to use the automatic nmap function there is possibility for errors due to nmap requiring root privileges.

This pull request solves this issue by only using sudo rights when calling nmap. If threader3000 is called without sudo rights it will continue normally until it calls nmap were it prepends sudo to the command. If threader3000 is initially called with root privs functionality will be as before.